### PR TITLE
Correct HashFileJob default value

### DIFF
--- a/docs/shoko-server/dashboard.md
+++ b/docs/shoko-server/dashboard.md
@@ -41,7 +41,7 @@ const jobNameColumns = [
 const jobNameData = [
     {
       'Job Name': 'HashFileJob',
-      'Default': '1',
+      'Default': '2',
       'Description': 'Determines how many workers are allocated to hashing files'
     },
     {


### PR DESCRIPTION
This should be two for the default.

See https://github.com/ShokoAnime/ShokoServer/blob/50099e21ff43e5e3c0e3c8b5bde2650799aceb04/Shoko.Server/Settings/QuartzSettings.cs#L37