### PR TITLE
Add SYS_PTRACE capability for .NET crash dump support

### DIFF
--- a/docs/.vitepress/components/DockerCompose.vue
+++ b/docs/.vitepress/components/DockerCompose.vue
@@ -125,6 +125,9 @@ services:
     container_name: ${userInput.value.container}
     image: ghcr.io/shokoanime/server:latest
     restart: always
+    cap_add:
+      # Required for .NET crash dump generation (segfault diagnosis)
+      - SYS_PTRACE
     environment:
       - "PUID=${userInput.value.puid}"
       - "PGID=${userInput.value.pgid}"

--- a/docs/public/files/synology-dockerfile.json
+++ b/docs/public/files/synology-dockerfile.json
@@ -1,5 +1,5 @@
 {
-  "cap_add": null,
+  "cap_add": ["SYS_PTRACE"],
   "cap_drop": null,
   "cmd": "",
   "cpu_priority": 50,


### PR DESCRIPTION
Add cap_add SYS_PTRACE to the generated docker-compose.yml and synology Docker template. Required by .NET runtime to write crash dumps when the server segfaults.